### PR TITLE
Update dependencies for Python 3.14 compatibility

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,10 +1,10 @@
-fastapi==0.104.1
-uvicorn[standard]==0.24.0
-sqlalchemy==2.0.23
-alembic==1.12.1
-pydantic-settings==2.1.0
-python-dotenv==1.0.0
-httpx==0.25.2
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+sqlalchemy>=2.0.36
+alembic>=1.14.0
+pydantic-settings>=2.6.0
+python-dotenv>=1.0.0
+httpx>=0.27.0
 
 # Optional PostgreSQL support (uncomment if using PostgreSQL instead of SQLite)
 # psycopg2-binary==2.9.9


### PR DESCRIPTION
Upgraded SQLAlchemy and other dependencies to versions that support Python 3.14.

Key changes:
- sqlalchemy: 2.0.23 → >=2.0.36 (fixes Python 3.14 typing issues)
- fastapi: 0.104.1 → >=0.115.0 (latest with improvements)
- uvicorn: 0.24.0 → >=0.32.0 (latest stable)
- alembic: 1.12.1 → >=1.14.0 (compatible with new SQLAlchemy)
- pydantic-settings: 2.1.0 → >=2.6.0 (latest)
- httpx: 0.25.2 → >=0.27.0 (latest)

Changed from exact versions (==) to minimum versions (>=) to allow pip to resolve compatible versions automatically.

Fixes: AssertionError in SQLAlchemy when using Python 3.14