### PR TITLE
Add SECRET_KEY generation to all install scripts

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -175,12 +175,19 @@ cd api
 
 REM Create .env file if not keeping existing
 if not defined KEEP_EXISTING (
+    REM Generate a secure secret key
+    for /f "delims=" %%i in ('%PYTHON_CMD% -c "import secrets; print(secrets.token_urlsafe(32))" 2^>nul') do set SECRET_KEY=%%i
+    if "!SECRET_KEY!"=="" set SECRET_KEY=change-me-%RANDOM%-%RANDOM%
+
     echo Creating api\.env configuration...
     (
         echo # Claude-Nine API Configuration (Local Setup^)
         echo.
         echo # Database - SQLite (no cloud database needed^)
         echo DATABASE_URL=sqlite:///./claude_nine.db
+        echo.
+        echo # Security
+        echo SECRET_KEY=!SECRET_KEY!
         echo.
         echo # Anthropic API Key (required for Claude AI^)
         echo ANTHROPIC_API_KEY=!ANTHROPIC_API_KEY!

--- a/install.ps1
+++ b/install.ps1
@@ -222,6 +222,18 @@ Push-Location api
 
 # Create .env file if not keeping existing
 if (-not $keepExisting) {
+    # Generate a secure secret key
+    try {
+        $secretKey = & $pythonCmd -c "import secrets; print(secrets.token_urlsafe(32))" 2>$null
+        if ([string]::IsNullOrWhiteSpace($secretKey)) {
+            throw "Python failed to generate key"
+        }
+    }
+    catch {
+        # Fallback to PowerShell random
+        $secretKey = "change-me-$(Get-Random)-$(Get-Date -Format 'yyyyMMddHHmmss')"
+    }
+
     Write-Host "Creating api\.env configuration..."
 
     $envContent = @"
@@ -229,6 +241,9 @@ if (-not $keepExisting) {
 
 # Database - SQLite (no cloud database needed)
 DATABASE_URL=sqlite:///./claude_nine.db
+
+# Security
+SECRET_KEY=$secretKey
 
 # Anthropic API Key (required for Claude AI)
 ANTHROPIC_API_KEY=$anthropicApiKey

--- a/install.sh
+++ b/install.sh
@@ -178,6 +178,9 @@ echo ""
 
 cd api
 
+# Generate a secure secret key
+SECRET_KEY=$(python -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || openssl rand -base64 32 2>/dev/null || echo "change-me-$(date +%s)-$(shuf -i 1000-9999 -n 1)")
+
 # Create .env file
 echo "Creating api/.env configuration..."
 cat > .env << EOF
@@ -185,6 +188,9 @@ cat > .env << EOF
 
 # Database - SQLite (no cloud database needed)
 DATABASE_URL=sqlite:///./claude_nine.db
+
+# Security
+SECRET_KEY=$SECRET_KEY
 
 # Anthropic API Key (required for Claude AI)
 ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY


### PR DESCRIPTION
The API config requires a secret_key field that was missing from the generated .env files, causing a Pydantic validation error on startup.

Changes to all three installers:
- Generate a secure random secret key using Python's secrets module
- Fallback methods if Python generation fails (openssl, random numbers)
- Add SECRET_KEY field to generated .env files

install.sh:
- Uses: python secrets.token_urlsafe(32) || openssl rand || date+shuf

install.bat:
- Uses: python secrets.token_urlsafe(32) || %RANDOM%-%RANDOM%

install.ps1:
- Uses: python secrets.token_urlsafe(32) || Get-Random+timestamp

Fixes: pydantic_core.ValidationError: secret_key Field required