### PR TITLE
Fix Next.js hydration errors in Tutorial and home page

### DIFF
--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -18,9 +18,15 @@ interface HealthStatus {
 export default function Home() {
   const [apiHealth, setApiHealth] = useState<HealthStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mounted, setMounted] = useState(false);
   const { toasts, removeToast, success } = useToast();
   const { isConnected } = useWebSocket("ws://localhost:8000/ws");
   const { startTutorial } = useTutorial();
+
+  // Wait for client-side hydration
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     fetch("http://localhost:8000/health")
@@ -41,8 +47,10 @@ export default function Home() {
     }
   }, [isConnected, success]);
 
-  // Start tutorial on first visit
+  // Start tutorial on first visit (only after mounted)
   useEffect(() => {
+    if (!mounted) return;
+
     const completed = localStorage.getItem("claude-nine-tutorial-completed");
     if (!completed) {
       // Delay to ensure page is fully rendered
@@ -51,7 +59,7 @@ export default function Home() {
       }, 1500);
       return () => clearTimeout(timer);
     }
-  }, [startTutorial]);
+  }, [startTutorial, mounted]);
 
   return (
     <div className="min-h-screen flex flex-col">

--- a/dashboard/components/Tutorial.tsx
+++ b/dashboard/components/Tutorial.tsx
@@ -29,9 +29,13 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   const [steps, setSteps] = useState<Step[]>([]);
   const [isTutorialEnabled, setIsTutorialEnabled] = useState(true);
   const [stepIndex, setStepIndex] = useState(0);
+  const [mounted, setMounted] = useState(false);
 
+  // Wait for client-side hydration before accessing localStorage
   useEffect(() => {
-    // Load tutorial preference from localStorage
+    setMounted(true);
+
+    // Load tutorial preference from localStorage (client-side only)
     const enabled = localStorage.getItem("claude-nine-tutorial-enabled");
     if (enabled !== null) {
       setIsTutorialEnabled(enabled === "true");
@@ -95,43 +99,45 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       }}
     >
       {children}
-      <Joyride
-        steps={steps}
-        run={run}
-        stepIndex={stepIndex}
-        continuous
-        showProgress
-        showSkipButton
-        callback={handleJoyrideCallback}
-        styles={{
-          options: {
-            primaryColor: "#2563eb",
-            zIndex: 10000,
-          },
-          tooltip: {
-            fontSize: 14,
-          },
-          buttonNext: {
-            backgroundColor: "#2563eb",
-            borderRadius: "0.375rem",
-            padding: "0.5rem 1rem",
-          },
-          buttonBack: {
-            color: "#6b7280",
-            marginRight: "0.5rem",
-          },
-          buttonSkip: {
-            color: "#6b7280",
-          },
-        }}
-        locale={{
-          back: "Back",
-          close: "Close",
-          last: "Finish",
-          next: "Next",
-          skip: "Skip Tour",
-        }}
-      />
+      {mounted && (
+        <Joyride
+          steps={steps}
+          run={run}
+          stepIndex={stepIndex}
+          continuous
+          showProgress
+          showSkipButton
+          callback={handleJoyrideCallback}
+          styles={{
+            options: {
+              primaryColor: "#2563eb",
+              zIndex: 10000,
+            },
+            tooltip: {
+              fontSize: 14,
+            },
+            buttonNext: {
+              backgroundColor: "#2563eb",
+              borderRadius: "0.375rem",
+              padding: "0.5rem 1rem",
+            },
+            buttonBack: {
+              color: "#6b7280",
+              marginRight: "0.5rem",
+            },
+            buttonSkip: {
+              color: "#6b7280",
+            },
+          }}
+          locale={{
+            back: "Back",
+            close: "Close",
+            last: "Finish",
+            next: "Next",
+            skip: "Skip Tour",
+          }}
+        />
+      )}
     </TutorialContext.Provider>
   );
 }


### PR DESCRIPTION
Fixed hydration mismatches caused by accessing localStorage during initial render, which differs between server-side and client-side.

Changes to Tutorial.tsx:
- Add 'mounted' state to track client-side hydration
- Only access localStorage after component is mounted
- Only render Joyride component after hydration completes
- Prevents "Hydration failed" error on initial load

Changes to page.tsx:
- Add 'mounted' state to prevent premature localStorage access
- Wait for hydration before starting tutorial
- Ensures tutorial works on initial load

This fixes:
1. "API Checking..." stuck on initial load (hydration blocking render)
2. Tutorial not firing on first visit (localStorage accessed too early)
3. Hydration error on refresh ("initial UI does not match server")

After this fix, the page should work correctly on initial load without requiring a refresh.