### PR TITLE
Fix tutorial auto-progression bug in callback handler

### DIFF
--- a/dashboard/components/Tutorial.tsx
+++ b/dashboard/components/Tutorial.tsx
@@ -76,7 +76,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   };
 
   const handleJoyrideCallback = (data: CallBackProps) => {
-    const { status, type, index } = data;
+    const { status } = data;
     const finishedStatuses: string[] = [STATUS.FINISHED, STATUS.SKIPPED];
 
     if (finishedStatuses.includes(status)) {
@@ -84,9 +84,8 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       localStorage.setItem("claude-nine-tutorial-completed", "true");
     }
 
-    if (type === EVENTS.STEP_AFTER) {
-      setStepIndex(index + 1);
-    }
+    // Note: With continuous=true, Joyride manages step progression automatically.
+    // We don't need to manually update stepIndex here.
   };
 
   return (


### PR DESCRIPTION
The EVENTS.STEP_AFTER callback was manually incrementing stepIndex, which caused a chain reaction:
1. User clicks Next → step advances
2. STEP_AFTER fires → we set stepIndex++
3. Joyride sees new stepIndex → advances again
4. STEP_AFTER fires → we set stepIndex++
5. Infinite loop of auto-progression

With continuous=true, Joyride automatically manages step progression. We should only handle tour completion (FINISHED/SKIPPED), not manually update stepIndex in response to step transitions.

Now the tutorial correctly waits for user's Next button click at each step.