### PR TITLE
Switch Joyride to uncontrolled mode - remove stepIndex prop

### DIFF
--- a/dashboard/components/Tutorial.tsx
+++ b/dashboard/components/Tutorial.tsx
@@ -102,7 +102,6 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
         <Joyride
           steps={steps}
           run={run}
-          stepIndex={stepIndex}
           continuous
           showProgress
           showSkipButton


### PR DESCRIPTION
The issue was using controlled mode (stepIndex prop) without updating stepIndex in the callback, causing the tour to get stuck at step 0.

Solution: Remove stepIndex prop and let Joyride manage step progression internally. With continuous=true, Joyride automatically advances when the user clicks Next.

Controlled mode (stepIndex prop) requires manual state management. Uncontrolled mode (no stepIndex prop) lets Joyride handle it.

This allows proper step-by-step progression with manual Next clicks.