### PR TITLE
Upgrade pip before installing dependencies in all installers

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -222,12 +222,16 @@ if not defined KEEP_EXISTING (
 
 REM Install Python dependencies
 echo.
+echo Upgrading pip to latest version...
+%PYTHON_CMD% -m pip install --upgrade pip >nul 2>&1
+
 echo Installing Python dependencies...
 %PIP_CMD% install -r requirements.txt > "%TEMP%\claude-nine-pip-install.log" 2>&1
 if %errorlevel% equ 0 (
     echo [OK] Python dependencies installed
 ) else (
     echo [WARNING] Some issues during pip install. Check %TEMP%\claude-nine-pip-install.log if problems occur.
+    echo [WARNING] If you see permission errors, try running as Administrator.
 )
 
 cd ..

--- a/install.ps1
+++ b/install.ps1
@@ -279,6 +279,9 @@ LINEAR_API_KEY=$linearApiKey
 
 # Install Python dependencies
 Write-Host ""
+Write-Host "Upgrading pip to latest version..."
+& $pythonCmd -m pip install --upgrade pip > $null 2>&1
+
 Write-Host "Installing Python dependencies..."
 $pipLog = "$env:TEMP\claude-nine-pip-install.log"
 & $pipCmd install -r requirements.txt > $pipLog 2>&1
@@ -287,6 +290,7 @@ if ($LASTEXITCODE -eq 0) {
 }
 else {
     Write-Warning "Some issues during pip install. Check $pipLog if problems occur."
+    Write-Warning "If you see permission errors, try running PowerShell as Administrator."
 }
 
 Pop-Location

--- a/install.sh
+++ b/install.sh
@@ -224,6 +224,9 @@ echo -e "${GREEN}✓${NC} Configuration file created: api/.env"
 
 # Install Python dependencies
 echo ""
+echo "Upgrading pip to latest version..."
+$PYTHON_CMD -m pip install --upgrade pip >/dev/null 2>&1
+
 echo "Installing Python dependencies..."
 if $PIP_CMD install -r requirements.txt > /tmp/claude-nine-pip-install.log 2>&1; then
     echo -e "${GREEN}✓${NC} Python dependencies installed"


### PR DESCRIPTION
This prevents Windows permission errors like:
"Could not install packages due to an OSError: [WinError 2] The system cannot find the file specified: websockets.exe -> websockets.exe.deleteme"

Changes to all installers:
- Upgrade pip to latest version before installing requirements
- Add helpful warning messages about running as Administrator
- Silently upgrade pip (no output spam)

This fixes the common issue where older pip versions can't properly replace existing executables in Scripts directory on Windows.

The error typically occurs when:
1. pip is outdated (e.g., 21.2.4 vs 25.3)
2. Scripts are locked or in use
3. Insufficient permissions

Upgrading pip first resolves most of these issues.