### PR TITLE
Add local work item management system with SQLite

### DIFF
--- a/claude-multi-agent-orchestrator/WORK_ITEMS.md
+++ b/claude-multi-agent-orchestrator/WORK_ITEMS.md
@@ -1,0 +1,497 @@
+# Local Work Item Management for CLAUDE-9
+
+A standalone work item tracking system that stores items in SQLite, supports team assignment, and exports to CLAUDE-9 task format.
+
+## Why Use This?
+
+- **No External Dependencies**: Works without Jira, Azure DevOps, or other tools
+- **Local-First**: All data stored in SQLite on your machine
+- **Team Support**: Organize work items by teams
+- **CLAUDE-9 Integration**: Export directly to orchestrator YAML format
+- **Simple**: Easy CLI interface for managing everything
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+pip install click tabulate
+# Already included if you installed from requirements.txt
+```
+
+### 2. Create Your First Team
+
+```bash
+python work_item_cli.py team create "Backend Team" "Backend development"
+```
+
+### 3. Create a Work Item
+
+```bash
+python work_item_cli.py item create "User Authentication" \
+  --description "Implement JWT auth with login/register" \
+  --type feature \
+  --priority high \
+  --team 1 \
+  --assigned-to Alice \
+  --tags "auth,security" \
+  --hours 16
+```
+
+### 4. Mark It Ready for CLAUDE-9
+
+```bash
+python work_item_cli.py item ready 1
+```
+
+### 5. Export and Run
+
+```bash
+# Export to YAML
+python work_item_cli.py export tasks/my-work.yaml --status ready
+
+# Run CLAUDE-9
+python orchestrator.py --tasks tasks/my-work.yaml
+```
+
+## Complete CLI Reference
+
+### Team Commands
+
+**Create a team:**
+```bash
+python work_item_cli.py team create "Team Name" "Description"
+```
+
+**List all teams:**
+```bash
+python work_item_cli.py team list
+```
+
+**Show team summary:**
+```bash
+python work_item_cli.py team summary 1
+```
+
+### Work Item Commands
+
+**Create a work item:**
+```bash
+python work_item_cli.py item create "Title" \
+  --description "Detailed description" \
+  --type [feature|bug|task|story|epic] \
+  --priority [low|medium|high|critical] \
+  --team TEAM_ID \
+  --assigned-to "Person Name" \
+  --tags "tag1,tag2,tag3" \
+  --hours 8.5
+```
+
+**List work items:**
+```bash
+# All items
+python work_item_cli.py item list
+
+# Filter by status
+python work_item_cli.py item list --status ready
+
+# Filter by team
+python work_item_cli.py item list --team 1
+
+# Filter by type
+python work_item_cli.py item list --type feature
+
+# Filter by assignee
+python work_item_cli.py item list --assigned-to Alice
+
+# Combine filters
+python work_item_cli.py item list --status ready --team 1
+```
+
+**Show item details:**
+```bash
+python work_item_cli.py item show 1
+```
+
+**Update a work item:**
+```bash
+python work_item_cli.py item update 1 \
+  --status in_progress \
+  --priority critical \
+  --assigned-to Bob
+```
+
+**Add a comment:**
+```bash
+python work_item_cli.py item comment 1 "Alice" "Started working on this"
+```
+
+**Mark item as ready:**
+```bash
+python work_item_cli.py item ready 1
+```
+
+**Mark item as complete:**
+```bash
+python work_item_cli.py item complete 1
+```
+
+### Export and Run Commands
+
+**Export to YAML:**
+```bash
+# Export ready items
+python work_item_cli.py export tasks/work.yaml
+
+# Export specific status
+python work_item_cli.py export tasks/work.yaml --status ready
+
+# Export for specific team
+python work_item_cli.py export tasks/work.yaml --team 1
+```
+
+**Export and run in one command:**
+```bash
+python work_item_cli.py run tasks/work.yaml
+```
+
+**Show statistics:**
+```bash
+python work_item_cli.py stats
+```
+
+## Workflow Examples
+
+### Scenario 1: Planning a Sprint
+
+```bash
+# Create teams
+python work_item_cli.py team create "Backend" "API development"
+python work_item_cli.py team create "Frontend" "UI development"
+
+# Create work items
+python work_item_cli.py item create "JWT Authentication" \
+  --type feature --priority high --team 1 --assigned-to Alice --hours 16
+
+python work_item_cli.py item create "API Logging" \
+  --type feature --priority medium --team 1 --assigned-to Bob --hours 8
+
+python work_item_cli.py item create "Dashboard UI" \
+  --type feature --priority high --team 2 --assigned-to Carol --hours 24
+
+# View what you have
+python work_item_cli.py item list
+
+# Mark items ready for development
+python work_item_cli.py item ready 1
+python work_item_cli.py item ready 2
+python work_item_cli.py item ready 3
+
+# Export and run
+python work_item_cli.py run tasks/sprint-1.yaml
+```
+
+### Scenario 2: Bug Tracking
+
+```bash
+# Create a bug
+python work_item_cli.py item create "Login fails with special characters" \
+  --type bug \
+  --priority critical \
+  --team 1 \
+  --assigned-to Alice \
+  --tags "bug,auth,urgent"
+
+# Add investigation notes
+python work_item_cli.py item comment 1 "Alice" \
+  "Found issue in password validation regex"
+
+# Mark ready for fix
+python work_item_cli.py item ready 1
+
+# After CLAUDE-9 fixes it
+python work_item_cli.py item complete 1
+```
+
+### Scenario 3: Feature Request Pipeline
+
+```bash
+# New feature request comes in
+python work_item_cli.py item create "Dark Mode Support" \
+  --type feature \
+  --priority low \
+  --team 2 \
+  --description "Add dark mode toggle to settings" \
+  --tags "ui,accessibility"
+
+# During planning, update priority
+python work_item_cli.py item update 1 --priority high
+
+# Assign and mark ready
+python work_item_cli.py item update 1 --assigned-to Carol
+python work_item_cli.py item ready 1
+
+# Export for this team only
+python work_item_cli.py export tasks/frontend-work.yaml --team 2 --status ready
+```
+
+## Database Schema
+
+Work items are stored in `.agent-workspace/work_items.db` with these tables:
+
+### Teams
+- id (PRIMARY KEY)
+- name (UNIQUE)
+- description
+- created_at
+
+### Work Items
+- id (PRIMARY KEY)
+- title
+- description
+- work_item_type (feature, bug, task, story, epic)
+- status (new, ready, in_progress, completed, blocked)
+- priority (low, medium, high, critical)
+- team_id (FOREIGN KEY)
+- assigned_to
+- branch_name (auto-generated)
+- estimated_hours
+- tags (JSON)
+- metadata (JSON)
+- created_at
+- updated_at
+
+### Comments
+- id (PRIMARY KEY)
+- work_item_id (FOREIGN KEY)
+- author
+- content
+- created_at
+
+### Attachments
+- id (PRIMARY KEY)
+- work_item_id (FOREIGN KEY)
+- filename
+- file_path
+- file_type
+- created_at
+
+## Programmatic Usage
+
+You can also use the `WorkItemManager` class directly in Python:
+
+```python
+from work_item_manager import WorkItemManager
+
+# Initialize
+manager = WorkItemManager()
+
+# Create team
+team_id = manager.create_team("Backend", "Backend dev team")
+
+# Create work item
+item_id = manager.create_work_item(
+    title="User Auth",
+    description="Implement JWT authentication",
+    work_item_type="feature",
+    priority="high",
+    team_id=team_id,
+    assigned_to="Alice",
+    tags=["auth", "security"],
+    estimated_hours=16.0
+)
+
+# Add comment
+manager.add_comment(item_id, "Alice", "Starting implementation")
+
+# Mark ready
+manager.mark_as_ready(item_id)
+
+# Export to CLAUDE-9
+manager.export_to_claude9_yaml('tasks/auth-work.yaml', status='ready')
+
+# Get team summary
+summary = manager.get_team_summary(team_id)
+print(summary)
+
+# Close connection
+manager.close()
+```
+
+## Status Workflow
+
+Work items follow this typical status flow:
+
+```
+new → ready → in_progress → completed
+  ↓            ↓
+  ↓----→ blocked
+```
+
+- **new**: Just created, not yet planned
+- **ready**: Ready for CLAUDE-9 to work on
+- **in_progress**: Currently being worked on
+- **completed**: Finished
+- **blocked**: Waiting on dependencies
+
+## Integration with CLAUDE-9
+
+When you export work items to YAML, they're converted to CLAUDE-9 task format:
+
+**Work Item:**
+```
+Title: User Authentication
+Type: feature
+Description: Implement JWT auth
+Team: Backend Team
+Assigned: Alice
+Tags: auth, security
+```
+
+**Exported YAML:**
+```yaml
+features:
+  - name: user_authentication
+    role: Feature Developer
+    goal: Implement User Authentication
+    branch: feature/user-authentication
+    description: |
+      Implement JWT auth
+
+      Assigned to: Alice
+      Estimated: 16.0 hours
+      Tags: auth, security
+    expected_output: Complete feature: User Authentication
+```
+
+## Tips and Best Practices
+
+### 1. Use Meaningful Titles
+- ✅ "Implement JWT authentication with refresh tokens"
+- ❌ "Auth stuff"
+
+### 2. Add Detailed Descriptions
+Include requirements, acceptance criteria, and technical notes.
+
+### 3. Use Tags Effectively
+- Group related items: `["auth", "security"]`
+- Mark technical debt: `["tech-debt", "refactor"]`
+- Flag urgent items: `["urgent", "hotfix"]`
+
+### 4. Estimate Realistically
+Provide estimated hours for better team planning.
+
+### 5. Comment Regularly
+Use comments to track progress, decisions, and blockers.
+
+### 6. Keep Teams Organized
+Create teams based on your actual team structure or technical areas.
+
+### 7. Use Status Appropriately
+Only mark items as "ready" when they have sufficient detail for CLAUDE-9 to work on them.
+
+## Backup and Restore
+
+### Backup
+```bash
+# Database is just SQLite, copy the file
+cp .agent-workspace/work_items.db backups/work_items_$(date +%Y%m%d).db
+```
+
+### Restore
+```bash
+cp backups/work_items_20250101.db .agent-workspace/work_items.db
+```
+
+### Export to JSON (for portability)
+```python
+import sqlite3
+import json
+
+conn = sqlite3.connect('.agent-workspace/work_items.db')
+conn.row_factory = sqlite3.Row
+
+# Export all work items
+cursor = conn.cursor()
+cursor.execute('SELECT * FROM work_items')
+items = [dict(row) for row in cursor.fetchall()]
+
+with open('work_items_export.json', 'w') as f:
+    json.dump(items, f, indent=2)
+```
+
+## Troubleshooting
+
+### Database locked error
+If you get "database is locked", make sure no other process is accessing the database.
+
+### Work items not exporting
+Check the status filter. Only items with `status='ready'` export by default.
+
+### CLI not found
+Make sure you're in the orchestrator directory:
+```bash
+cd claude-multi-agent-orchestrator
+python work_item_cli.py --help
+```
+
+## Advanced Features
+
+### Custom Metadata
+Store any additional data in the metadata field:
+
+```python
+manager.create_work_item(
+    title="Complex Feature",
+    metadata={
+        "epic_id": "EPIC-123",
+        "sprint": "Sprint 5",
+        "story_points": 8,
+        "acceptance_criteria": [
+            "User can login",
+            "Token expires correctly",
+            "Refresh works"
+        ]
+    }
+)
+```
+
+### Attachments
+Track files associated with work items:
+
+```python
+# SQL to add attachment
+cursor.execute('''
+    INSERT INTO attachments (work_item_id, filename, file_path, file_type)
+    VALUES (?, ?, ?, ?)
+''', (item_id, 'mockup.png', '/path/to/mockup.png', 'image/png'))
+```
+
+### Custom Queries
+Access the SQLite database directly for custom reporting:
+
+```bash
+sqlite3 .agent-workspace/work_items.db
+
+# Get high priority items
+SELECT * FROM work_items WHERE priority = 'high' AND status != 'completed';
+
+# Get team workload
+SELECT t.name, COUNT(*) as item_count, SUM(wi.estimated_hours) as total_hours
+FROM work_items wi
+JOIN teams t ON wi.team_id = t.id
+WHERE wi.status != 'completed'
+GROUP BY t.name;
+```
+
+## Next Steps
+
+1. Create your teams
+2. Add your work items
+3. Mark items as "ready"
+4. Export and run with CLAUDE-9
+5. Track progress and iterate!
+
+---
+
+**Built for CLAUDE-9 - Multi-Agent Orchestration Powered by Claude**

--- a/claude-multi-agent-orchestrator/requirements.txt
+++ b/claude-multi-agent-orchestrator/requirements.txt
@@ -3,3 +3,5 @@ crewai-tools>=0.12.0
 gitpython>=3.1.40
 anthropic>=0.39.0
 pyyaml>=6.0.1
+click>=8.1.0
+tabulate>=0.9.0

--- a/claude-multi-agent-orchestrator/work_item_cli.py
+++ b/claude-multi-agent-orchestrator/work_item_cli.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+CLI for managing local work items for CLAUDE-9.
+
+Usage:
+    python work_item_cli.py team create "Backend Team" "Backend developers"
+    python work_item_cli.py item create "Add auth" --team 1 --assigned-to Alice
+    python work_item_cli.py item list --status ready
+    python work_item_cli.py export tasks/my-work.yaml --status ready
+    python work_item_cli.py run tasks/my-work.yaml
+"""
+
+import click
+import sys
+import subprocess
+from tabulate import tabulate
+from work_item_manager import WorkItemManager
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    """CLAUDE-9 Work Item Management CLI"""
+    ctx.ensure_object(dict)
+    ctx.obj['manager'] = WorkItemManager()
+
+
+@cli.group()
+def team():
+    """Manage teams"""
+    pass
+
+
+@team.command('create')
+@click.argument('name')
+@click.argument('description', required=False, default='')
+@click.pass_context
+def team_create(ctx, name, description):
+    """Create a new team"""
+    manager = ctx.obj['manager']
+    team_id = manager.create_team(name, description)
+    click.echo(f"✓ Created team: {name} (ID: {team_id})")
+
+
+@team.command('list')
+@click.pass_context
+def team_list(ctx):
+    """List all teams"""
+    manager = ctx.obj['manager']
+    teams = manager.list_teams()
+
+    if not teams:
+        click.echo("No teams found")
+        return
+
+    table_data = []
+    for team in teams:
+        table_data.append([
+            team['id'],
+            team['name'],
+            team['description'],
+            team['created_at']
+        ])
+
+    headers = ['ID', 'Name', 'Description', 'Created']
+    click.echo(tabulate(table_data, headers=headers, tablefmt='grid'))
+
+
+@team.command('summary')
+@click.argument('team_id', type=int)
+@click.pass_context
+def team_summary(ctx, team_id):
+    """Show team summary with statistics"""
+    manager = ctx.obj['manager']
+    summary = manager.get_team_summary(team_id)
+
+    if not summary['team']:
+        click.echo(f"Team {team_id} not found", err=True)
+        return
+
+    click.echo(f"\n📊 Team: {summary['team']['name']}")
+    click.echo(f"   {summary['team']['description']}\n")
+
+    click.echo("Status Breakdown:")
+    for status, count in summary['status_counts'].items():
+        click.echo(f"  {status:15} {count:3} items")
+
+    click.echo("\nType Breakdown:")
+    for work_type, count in summary['type_counts'].items():
+        click.echo(f"  {work_type:15} {count:3} items")
+
+    click.echo(f"\nTotal Estimated Hours: {summary['total_estimated_hours']:.1f}")
+
+
+@cli.group()
+def item():
+    """Manage work items"""
+    pass
+
+
+@item.command('create')
+@click.argument('title')
+@click.option('--description', '-d', default='', help='Work item description')
+@click.option('--type', '-t', default='feature',
+              type=click.Choice(['feature', 'bug', 'task', 'story', 'epic']),
+              help='Work item type')
+@click.option('--priority', '-p', default='medium',
+              type=click.Choice(['low', 'medium', 'high', 'critical']),
+              help='Priority level')
+@click.option('--team', type=int, help='Team ID')
+@click.option('--assigned-to', help='Person assigned to')
+@click.option('--tags', help='Comma-separated tags')
+@click.option('--hours', type=float, help='Estimated hours')
+@click.pass_context
+def item_create(ctx, title, description, type, priority, team, assigned_to, tags, hours):
+    """Create a new work item"""
+    manager = ctx.obj['manager']
+
+    tags_list = [t.strip() for t in tags.split(',')] if tags else None
+
+    item_id = manager.create_work_item(
+        title=title,
+        description=description,
+        work_item_type=type,
+        priority=priority,
+        team_id=team,
+        assigned_to=assigned_to,
+        tags=tags_list,
+        estimated_hours=hours
+    )
+
+    click.echo(f"✓ Created work item: {title} (ID: {item_id})")
+
+
+@item.command('list')
+@click.option('--status', help='Filter by status')
+@click.option('--team', type=int, help='Filter by team ID')
+@click.option('--type', help='Filter by type')
+@click.option('--assigned-to', help='Filter by assignee')
+@click.pass_context
+def item_list(ctx, status, team, type, assigned_to):
+    """List work items"""
+    manager = ctx.obj['manager']
+
+    items = manager.list_work_items(
+        status=status,
+        team_id=team,
+        work_item_type=type,
+        assigned_to=assigned_to
+    )
+
+    if not items:
+        click.echo("No work items found")
+        return
+
+    table_data = []
+    for item in items:
+        tags_str = ', '.join(item['tags']) if item['tags'] else ''
+        table_data.append([
+            item['id'],
+            item['title'][:40],
+            item['work_item_type'],
+            item['status'],
+            item['priority'],
+            item['team_name'] or 'N/A',
+            item['assigned_to'] or 'N/A',
+            tags_str[:20]
+        ])
+
+    headers = ['ID', 'Title', 'Type', 'Status', 'Priority', 'Team', 'Assigned', 'Tags']
+    click.echo(tabulate(table_data, headers=headers, tablefmt='grid'))
+
+
+@item.command('show')
+@click.argument('item_id', type=int)
+@click.pass_context
+def item_show(ctx, item_id):
+    """Show detailed work item info"""
+    manager = ctx.obj['manager']
+
+    item = manager.get_work_item(item_id)
+    if not item:
+        click.echo(f"Work item {item_id} not found", err=True)
+        return
+
+    click.echo(f"\n📋 Work Item #{item['id']}: {item['title']}")
+    click.echo("=" * 80)
+    click.echo(f"Type:        {item['work_item_type']}")
+    click.echo(f"Status:      {item['status']}")
+    click.echo(f"Priority:    {item['priority']}")
+    click.echo(f"Team:        {item['team_name'] or 'N/A'}")
+    click.echo(f"Assigned:    {item['assigned_to'] or 'N/A'}")
+    click.echo(f"Branch:      {item['branch_name']}")
+    click.echo(f"Estimated:   {item['estimated_hours'] or 'N/A'} hours")
+    click.echo(f"Tags:        {', '.join(item['tags']) if item['tags'] else 'N/A'}")
+    click.echo(f"Created:     {item['created_at']}")
+    click.echo(f"Updated:     {item['updated_at']}")
+    click.echo(f"\nDescription:\n{item['description']}")
+
+    # Show comments
+    comments = manager.get_comments(item_id)
+    if comments:
+        click.echo(f"\n💬 Comments ({len(comments)}):")
+        for comment in comments:
+            click.echo(f"  [{comment['created_at']}] {comment['author']}:")
+            click.echo(f"    {comment['content']}")
+
+
+@item.command('update')
+@click.argument('item_id', type=int)
+@click.option('--status', type=click.Choice(['new', 'ready', 'in_progress', 'completed', 'blocked']))
+@click.option('--priority', type=click.Choice(['low', 'medium', 'high', 'critical']))
+@click.option('--team', type=int, help='Team ID')
+@click.option('--assigned-to', help='Person assigned to')
+@click.pass_context
+def item_update(ctx, item_id, status, priority, team, assigned_to):
+    """Update work item"""
+    manager = ctx.obj['manager']
+
+    success = manager.update_work_item(
+        item_id,
+        status=status,
+        priority=priority,
+        team_id=team,
+        assigned_to=assigned_to
+    )
+
+    if success:
+        click.echo(f"✓ Updated work item {item_id}")
+    else:
+        click.echo(f"No updates made to work item {item_id}")
+
+
+@item.command('comment')
+@click.argument('item_id', type=int)
+@click.argument('author')
+@click.argument('content')
+@click.pass_context
+def item_comment(ctx, item_id, author, content):
+    """Add a comment to work item"""
+    manager = ctx.obj['manager']
+
+    comment_id = manager.add_comment(item_id, author, content)
+    click.echo(f"✓ Added comment to work item {item_id}")
+
+
+@item.command('ready')
+@click.argument('item_id', type=int)
+@click.pass_context
+def item_ready(ctx, item_id):
+    """Mark work item as ready for CLAUDE-9"""
+    manager = ctx.obj['manager']
+    manager.mark_as_ready(item_id)
+    click.echo(f"✓ Marked work item {item_id} as ready")
+
+
+@item.command('complete')
+@click.argument('item_id', type=int)
+@click.pass_context
+def item_complete(ctx, item_id):
+    """Mark work item as completed"""
+    manager = ctx.obj['manager']
+    manager.mark_as_complete(item_id)
+    click.echo(f"✓ Marked work item {item_id} as completed")
+
+
+@cli.command()
+@click.argument('output_file')
+@click.option('--status', default='ready', help='Export items with this status')
+@click.option('--team', type=int, help='Export items for specific team')
+@click.pass_context
+def export(ctx, output_file, status, team):
+    """Export work items to CLAUDE-9 YAML format"""
+    manager = ctx.obj['manager']
+
+    result_file = manager.export_to_claude9_yaml(
+        output_file=output_file,
+        status=status,
+        team_id=team
+    )
+
+    click.echo(f"✓ Exported work items to {result_file}")
+    click.echo(f"\nTo run CLAUDE-9 with these tasks:")
+    click.echo(f"  python orchestrator.py --tasks {result_file}")
+
+
+@cli.command()
+@click.argument('tasks_file')
+@click.option('--config', default='config.yaml', help='Config file')
+@click.pass_context
+def run(ctx, tasks_file, config):
+    """Export work items and run CLAUDE-9 orchestrator"""
+    manager = ctx.obj['manager']
+
+    # Export ready items
+    click.echo("📦 Exporting ready work items...")
+    manager.export_to_claude9_yaml(tasks_file, status='ready')
+
+    # Run orchestrator
+    click.echo(f"\n🚀 Starting CLAUDE-9 orchestrator...")
+    click.echo(f"   Tasks: {tasks_file}")
+    click.echo(f"   Config: {config}\n")
+
+    try:
+        result = subprocess.run(
+            ['python', 'orchestrator.py', '--tasks', tasks_file, '--config', config],
+            check=True
+        )
+        click.echo("\n✓ Orchestrator completed successfully")
+    except subprocess.CalledProcessError as e:
+        click.echo(f"\n✗ Orchestrator failed with exit code {e.returncode}", err=True)
+        sys.exit(e.returncode)
+    except FileNotFoundError:
+        click.echo("\n✗ orchestrator.py not found. Run from orchestrator directory.", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+@click.pass_context
+def stats(ctx):
+    """Show overall statistics"""
+    manager = ctx.obj['manager']
+
+    all_items = manager.list_work_items()
+    teams = manager.list_teams()
+
+    click.echo(f"\n📊 CLAUDE-9 Work Item Statistics")
+    click.echo("=" * 50)
+    click.echo(f"Total Teams:       {len(teams)}")
+    click.echo(f"Total Work Items:  {len(all_items)}")
+
+    # Count by status
+    status_counts = {}
+    for item in all_items:
+        status = item['status']
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    click.echo(f"\nBy Status:")
+    for status, count in sorted(status_counts.items()):
+        click.echo(f"  {status:15} {count:3}")
+
+    # Count by type
+    type_counts = {}
+    for item in all_items:
+        work_type = item['work_item_type']
+        type_counts[work_type] = type_counts.get(work_type, 0) + 1
+
+    click.echo(f"\nBy Type:")
+    for work_type, count in sorted(type_counts.items()):
+        click.echo(f"  {work_type:15} {count:3}")
+
+    # Ready for CLAUDE-9
+    ready_count = status_counts.get('ready', 0)
+    click.echo(f"\n🚀 Ready for CLAUDE-9: {ready_count} items")
+
+
+if __name__ == '__main__':
+    try:
+        cli(obj={})
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)

--- a/claude-multi-agent-orchestrator/work_item_manager.py
+++ b/claude-multi-agent-orchestrator/work_item_manager.py
@@ -1,0 +1,549 @@
+"""
+Local Work Item Manager for CLAUDE-9
+
+A standalone work item tracking system that stores items in SQLite,
+supports team assignment, and exports to CLAUDE-9 task format.
+"""
+
+import sqlite3
+import yaml
+import json
+from datetime import datetime
+from typing import List, Dict, Optional, Tuple
+from pathlib import Path
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class WorkItemManager:
+    """
+    Manages work items in a local SQLite database.
+
+    Features:
+    - Create work items without external dependencies
+    - Assign work items to teams
+    - Export to CLAUDE-9 YAML format
+    - Track status and priority
+    - Add comments and attachments
+    """
+
+    def __init__(self, db_path: str = ".agent-workspace/work_items.db"):
+        """
+        Initialize the work item manager.
+
+        Args:
+            db_path: Path to SQLite database file
+        """
+        self.db_path = db_path
+
+        # Ensure directory exists
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        self.conn = sqlite3.connect(db_path)
+        self.conn.row_factory = sqlite3.Row  # Return rows as dictionaries
+        self._create_tables()
+
+        logger.info(f"Initialized WorkItemManager with database at {db_path}")
+
+    def _create_tables(self):
+        """Create database tables if they don't exist."""
+        cursor = self.conn.cursor()
+
+        # Teams table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS teams (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        # Work items table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS work_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                description TEXT,
+                work_item_type TEXT DEFAULT 'feature',
+                status TEXT DEFAULT 'new',
+                priority TEXT DEFAULT 'medium',
+                team_id INTEGER,
+                assigned_to TEXT,
+                branch_name TEXT,
+                estimated_hours REAL,
+                tags TEXT,
+                metadata TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (team_id) REFERENCES teams(id)
+            )
+        ''')
+
+        # Comments table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS comments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                work_item_id INTEGER NOT NULL,
+                author TEXT,
+                content TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (work_item_id) REFERENCES work_items(id) ON DELETE CASCADE
+            )
+        ''')
+
+        # Attachments table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS attachments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                work_item_id INTEGER NOT NULL,
+                filename TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                file_type TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (work_item_id) REFERENCES work_items(id) ON DELETE CASCADE
+            )
+        ''')
+
+        # Create indexes
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_work_items_team ON work_items(team_id)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_work_items_priority ON work_items(priority)')
+
+        self.conn.commit()
+        logger.info("Database tables created/verified")
+
+    # ==================== TEAM MANAGEMENT ====================
+
+    def create_team(self, name: str, description: str = "") -> int:
+        """
+        Create a new team.
+
+        Args:
+            name: Team name
+            description: Team description
+
+        Returns:
+            int: Team ID
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            'INSERT INTO teams (name, description) VALUES (?, ?)',
+            (name, description)
+        )
+        self.conn.commit()
+        team_id = cursor.lastrowid
+
+        logger.info(f"Created team: {name} (ID: {team_id})")
+        return team_id
+
+    def list_teams(self) -> List[Dict]:
+        """List all teams."""
+        cursor = self.conn.cursor()
+        cursor.execute('SELECT * FROM teams ORDER BY name')
+        teams = [dict(row) for row in cursor.fetchall()]
+        return teams
+
+    def get_team(self, team_id: int) -> Optional[Dict]:
+        """Get team by ID."""
+        cursor = self.conn.cursor()
+        cursor.execute('SELECT * FROM teams WHERE id = ?', (team_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    # ==================== WORK ITEM MANAGEMENT ====================
+
+    def create_work_item(
+        self,
+        title: str,
+        description: str = "",
+        work_item_type: str = "feature",
+        priority: str = "medium",
+        team_id: Optional[int] = None,
+        assigned_to: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        estimated_hours: Optional[float] = None,
+        metadata: Optional[Dict] = None
+    ) -> int:
+        """
+        Create a new work item.
+
+        Args:
+            title: Work item title
+            description: Detailed description
+            work_item_type: Type (feature, bug, task, story, epic)
+            priority: Priority (low, medium, high, critical)
+            team_id: Assigned team ID
+            assigned_to: Person assigned to
+            tags: List of tags
+            estimated_hours: Estimated effort in hours
+            metadata: Additional metadata as dict
+
+        Returns:
+            int: Work item ID
+        """
+        # Generate branch name
+        branch_name = f"{work_item_type}/{title.lower().replace(' ', '-')}"
+
+        # Serialize tags and metadata
+        tags_json = json.dumps(tags) if tags else None
+        metadata_json = json.dumps(metadata) if metadata else None
+
+        cursor = self.conn.cursor()
+        cursor.execute('''
+            INSERT INTO work_items (
+                title, description, work_item_type, priority, team_id,
+                assigned_to, branch_name, estimated_hours, tags, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            title, description, work_item_type, priority, team_id,
+            assigned_to, branch_name, estimated_hours, tags_json, metadata_json
+        ))
+        self.conn.commit()
+        work_item_id = cursor.lastrowid
+
+        logger.info(f"Created work item: {title} (ID: {work_item_id})")
+        return work_item_id
+
+    def update_work_item(
+        self,
+        work_item_id: int,
+        status: Optional[str] = None,
+        priority: Optional[str] = None,
+        team_id: Optional[int] = None,
+        assigned_to: Optional[str] = None
+    ) -> bool:
+        """Update work item fields."""
+        updates = []
+        params = []
+
+        if status:
+            updates.append('status = ?')
+            params.append(status)
+        if priority:
+            updates.append('priority = ?')
+            params.append(priority)
+        if team_id is not None:
+            updates.append('team_id = ?')
+            params.append(team_id)
+        if assigned_to is not None:
+            updates.append('assigned_to = ?')
+            params.append(assigned_to)
+
+        if not updates:
+            return False
+
+        updates.append('updated_at = CURRENT_TIMESTAMP')
+        params.append(work_item_id)
+
+        cursor = self.conn.cursor()
+        query = f"UPDATE work_items SET {', '.join(updates)} WHERE id = ?"
+        cursor.execute(query, params)
+        self.conn.commit()
+
+        logger.info(f"Updated work item {work_item_id}")
+        return True
+
+    def get_work_item(self, work_item_id: int) -> Optional[Dict]:
+        """Get work item by ID."""
+        cursor = self.conn.cursor()
+        cursor.execute('''
+            SELECT wi.*, t.name as team_name
+            FROM work_items wi
+            LEFT JOIN teams t ON wi.team_id = t.id
+            WHERE wi.id = ?
+        ''', (work_item_id,))
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        item = dict(row)
+
+        # Deserialize JSON fields
+        if item['tags']:
+            item['tags'] = json.loads(item['tags'])
+        if item['metadata']:
+            item['metadata'] = json.loads(item['metadata'])
+
+        return item
+
+    def list_work_items(
+        self,
+        status: Optional[str] = None,
+        team_id: Optional[int] = None,
+        work_item_type: Optional[str] = None,
+        assigned_to: Optional[str] = None
+    ) -> List[Dict]:
+        """
+        List work items with optional filters.
+
+        Args:
+            status: Filter by status
+            team_id: Filter by team
+            work_item_type: Filter by type
+            assigned_to: Filter by assignee
+
+        Returns:
+            List of work items
+        """
+        query = '''
+            SELECT wi.*, t.name as team_name
+            FROM work_items wi
+            LEFT JOIN teams t ON wi.team_id = t.id
+            WHERE 1=1
+        '''
+        params = []
+
+        if status:
+            query += ' AND wi.status = ?'
+            params.append(status)
+        if team_id:
+            query += ' AND wi.team_id = ?'
+            params.append(team_id)
+        if work_item_type:
+            query += ' AND wi.work_item_type = ?'
+            params.append(work_item_type)
+        if assigned_to:
+            query += ' AND wi.assigned_to = ?'
+            params.append(assigned_to)
+
+        query += ' ORDER BY wi.priority DESC, wi.created_at DESC'
+
+        cursor = self.conn.cursor()
+        cursor.execute(query, params)
+
+        items = []
+        for row in cursor.fetchall():
+            item = dict(row)
+            if item['tags']:
+                item['tags'] = json.loads(item['tags'])
+            if item['metadata']:
+                item['metadata'] = json.loads(item['metadata'])
+            items.append(item)
+
+        return items
+
+    # ==================== COMMENTS ====================
+
+    def add_comment(self, work_item_id: int, author: str, content: str) -> int:
+        """Add a comment to a work item."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            'INSERT INTO comments (work_item_id, author, content) VALUES (?, ?, ?)',
+            (work_item_id, author, content)
+        )
+        self.conn.commit()
+
+        logger.info(f"Added comment to work item {work_item_id}")
+        return cursor.lastrowid
+
+    def get_comments(self, work_item_id: int) -> List[Dict]:
+        """Get all comments for a work item."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            'SELECT * FROM comments WHERE work_item_id = ? ORDER BY created_at',
+            (work_item_id,)
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    # ==================== CLAUDE-9 INTEGRATION ====================
+
+    def export_to_claude9_yaml(
+        self,
+        output_file: str,
+        status: str = "ready",
+        team_id: Optional[int] = None
+    ) -> str:
+        """
+        Export work items to CLAUDE-9 YAML format.
+
+        Args:
+            output_file: Output YAML file path
+            status: Export items with this status (default: "ready")
+            team_id: Optional team filter
+
+        Returns:
+            str: Path to generated YAML file
+        """
+        # Get work items
+        work_items = self.list_work_items(status=status, team_id=team_id)
+
+        if not work_items:
+            logger.warning(f"No work items found with status '{status}'")
+            return output_file
+
+        # Convert to CLAUDE-9 task format
+        features = []
+        for item in work_items:
+            # Build description with details
+            description_parts = [item['description']]
+
+            if item['assigned_to']:
+                description_parts.append(f"\nAssigned to: {item['assigned_to']}")
+
+            if item['estimated_hours']:
+                description_parts.append(f"Estimated: {item['estimated_hours']} hours")
+
+            if item['tags']:
+                description_parts.append(f"Tags: {', '.join(item['tags'])}")
+
+            # Get comments
+            comments = self.get_comments(item['id'])
+            if comments:
+                description_parts.append("\n\nComments:")
+                for comment in comments:
+                    description_parts.append(f"- {comment['author']}: {comment['content']}")
+
+            feature = {
+                'name': item['title'].lower().replace(' ', '_'),
+                'role': f"{item['work_item_type'].title()} Developer",
+                'goal': f"Implement {item['title']}",
+                'branch': item['branch_name'],
+                'description': '\n'.join(description_parts),
+                'expected_output': f"Complete {item['work_item_type']}: {item['title']}"
+            }
+
+            features.append(feature)
+
+        # Write YAML
+        output_data = {'features': features}
+
+        with open(output_file, 'w') as f:
+            yaml.dump(output_data, f, default_flow_style=False, sort_keys=False)
+
+        logger.info(f"Exported {len(features)} work items to {output_file}")
+        return output_file
+
+    def mark_as_complete(self, work_item_id: int) -> bool:
+        """Mark work item as complete."""
+        return self.update_work_item(work_item_id, status='completed')
+
+    def mark_as_in_progress(self, work_item_id: int) -> bool:
+        """Mark work item as in progress."""
+        return self.update_work_item(work_item_id, status='in_progress')
+
+    def mark_as_ready(self, work_item_id: int) -> bool:
+        """Mark work item as ready for CLAUDE-9."""
+        return self.update_work_item(work_item_id, status='ready')
+
+    # ==================== REPORTING ====================
+
+    def get_team_summary(self, team_id: int) -> Dict:
+        """Get summary statistics for a team."""
+        cursor = self.conn.cursor()
+
+        # Count by status
+        cursor.execute('''
+            SELECT status, COUNT(*) as count
+            FROM work_items
+            WHERE team_id = ?
+            GROUP BY status
+        ''', (team_id,))
+
+        status_counts = {row['status']: row['count'] for row in cursor.fetchall()}
+
+        # Count by type
+        cursor.execute('''
+            SELECT work_item_type, COUNT(*) as count
+            FROM work_items
+            WHERE team_id = ?
+            GROUP BY work_item_type
+        ''', (team_id,))
+
+        type_counts = {row['work_item_type']: row['count'] for row in cursor.fetchall()}
+
+        # Total estimated hours
+        cursor.execute('''
+            SELECT SUM(estimated_hours) as total_hours
+            FROM work_items
+            WHERE team_id = ?
+        ''', (team_id,))
+
+        total_hours = cursor.fetchone()['total_hours'] or 0
+
+        team = self.get_team(team_id)
+
+        return {
+            'team': team,
+            'status_counts': status_counts,
+            'type_counts': type_counts,
+            'total_estimated_hours': total_hours
+        }
+
+    def close(self):
+        """Close database connection."""
+        self.conn.close()
+        logger.info("Database connection closed")
+
+
+# ==================== EXAMPLE USAGE ====================
+
+if __name__ == "__main__":
+    # Example: Create work items and export to CLAUDE-9
+
+    manager = WorkItemManager()
+
+    # Create teams
+    backend_team = manager.create_team("Backend Team", "Backend development team")
+    frontend_team = manager.create_team("Frontend Team", "Frontend development team")
+
+    # Create work items
+    auth_id = manager.create_work_item(
+        title="User Authentication System",
+        description="Implement JWT-based authentication with login, register, and token refresh",
+        work_item_type="feature",
+        priority="high",
+        team_id=backend_team,
+        assigned_to="Alice",
+        tags=["auth", "security", "backend"],
+        estimated_hours=16.0
+    )
+
+    logging_id = manager.create_work_item(
+        title="API Request Logging",
+        description="Add Winston logging for all API requests with request/response tracking",
+        work_item_type="feature",
+        priority="medium",
+        team_id=backend_team,
+        assigned_to="Bob",
+        tags=["logging", "observability"],
+        estimated_hours=8.0
+    )
+
+    ui_id = manager.create_work_item(
+        title="Dashboard UI Components",
+        description="Create reusable React components for dashboard",
+        work_item_type="feature",
+        priority="high",
+        team_id=frontend_team,
+        assigned_to="Carol",
+        tags=["ui", "react", "components"],
+        estimated_hours=24.0
+    )
+
+    # Add comments
+    manager.add_comment(auth_id, "Alice", "Need to decide on token expiration policy")
+    manager.add_comment(auth_id, "Manager", "Let's use 24h expiration with 7d refresh tokens")
+
+    # Mark items as ready for CLAUDE-9
+    manager.mark_as_ready(auth_id)
+    manager.mark_as_ready(logging_id)
+
+    # Export to CLAUDE-9 format
+    manager.export_to_claude9_yaml(
+        'tasks/work-items.yaml',
+        status='ready',
+        team_id=backend_team
+    )
+
+    # Get team summary
+    summary = manager.get_team_summary(backend_team)
+    print(f"\nTeam Summary for {summary['team']['name']}:")
+    print(f"  Status counts: {summary['status_counts']}")
+    print(f"  Type counts: {summary['type_counts']}")
+    print(f"  Total estimated hours: {summary['total_estimated_hours']}")
+
+    manager.close()


### PR DESCRIPTION
Created a standalone work item tracking system that doesn't require external tools (Jira, Azure DevOps, etc.). Work items are stored locally in SQLite and can be exported to CLAUDE-9 YAML format.

New Files:
- work_item_manager.py: Core SQLite-based work item manager
  - Team management (create, list, summaries)
  - Work item CRUD operations
  - Comments and attachments support
  - Export to CLAUDE-9 YAML format
  - Status tracking and reporting

- work_item_cli.py: Comprehensive CLI interface
  - Team commands (create, list, summary)
  - Item commands (create, list, show, update, comment, ready, complete)
  - Export commands (export, run, stats)
  - Beautiful table formatting with tabulate

- WORK_ITEMS.md: Complete documentation
  - Quick start guide
  - Full CLI reference
  - Workflow examples
  - Database schema
  - Integration guide
  - Best practices

Features:
- ✓ Create work items without external dependencies
- ✓ Organize by teams
- ✓ Track status (new, ready, in_progress, completed, blocked)
- ✓ Set priority (low, medium, high, critical)
- ✓ Add tags and metadata
- ✓ Estimate hours
- ✓ Add comments
- ✓ Export to CLAUDE-9 YAML
- ✓ Run orchestrator directly from CLI
- ✓ Team and overall statistics

Database Schema:
- teams: Team information
- work_items: Core work item data with JSON fields
- comments: Discussion threads
- attachments: File tracking

Updated requirements.txt with click and tabulate dependencies.