### PR TITLE
Fix 422 error when adding agents via UI

### DIFF
--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -73,7 +73,7 @@ class AgentBase(BaseModel):
 
 
 class AgentCreate(AgentBase):
-    team_id: UUID4
+    pass
 
 
 class Agent(AgentBase):


### PR DESCRIPTION
Remove team_id requirement from AgentCreate schema since it's provided in the URL path parameter. The endpoint already uses team_id from the path and excludes it from the request body.

Fixes validation error: "Failed to add agent" with 422 status code