### PR TITLE
Add Run Completion Summary (Issue #36)

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -191,6 +191,7 @@ class Run(Base):
     started_at = Column(DateTime(timezone=True))
     completed_at = Column(DateTime(timezone=True))
     error_message = Column(Text)
+    completion_summary = Column(JSON)  # Summary of run completion (branches, files, stats)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -220,6 +220,7 @@ class Run(RunBase):
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     error_message: Optional[str] = None
+    completion_summary: Optional[dict] = None  # Summary of run completion
     created_at: datetime
     updated_at: datetime
     tasks: List[RunTask] = []


### PR DESCRIPTION
## Summary

When a run completes successfully, generates and stores a summary providing a clear overview of what was accomplished.

### Example Summary Format

```
Summary:
- Branch: integration/d4e0b747
- All 4 feature branches merged: test-001, test-002, test-003, test-004 ✓
- 17 files changed with ~3,400 lines of new code
- Work includes:
  - Input validation
  - User preferences API
  - Authentication module
  - Documentation and tests
```

## Changes

### API
- **models.py**: Add `completion_summary` JSON field to Run model
- **schemas.py**: Add `completion_summary` Optional[dict] to Run schema
- **routes/runs.py**: Add `PATCH /api/runs/{run_id}/complete` endpoint

### Orchestrator
- **orchestrator.py**: Add summary generation methods:
  - `_get_diff_stats()` - Parse git diff --stat output
  - `generate_completion_summary()` - Build summary from merge result
  - `_update_run_completion()` - Send summary to API
  - Post-completion Phase 4 integrated into run() method

### Tests
- **test_runs.py**: Add 3 tests for complete endpoint:
  - Complete run with summary data
  - Complete nonexistent run (404)
  - Validate summary fields (422)

## Acceptance Criteria

- [x] Run completion triggers summary generation
- [x] Summary includes integration branch name
- [x] Summary lists all merged feature branches
- [x] Summary shows files changed and lines of code stats
- [x] Summary describes the work completed for each task
- [x] Summary stored in Run model (visible via API)

## Test Results

```
72 passed (69 existing + 3 new)
```

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)